### PR TITLE
Update Crazy.java

### DIFF
--- a/Crazy.java
+++ b/Crazy.java
@@ -96,7 +96,7 @@ class Crazy
 				}while(ball<0 || ball>10);                         //CPU batting logic based on NRR- CPU checks RRR and generates the throw accordingly
 				if(target!=0)
 				{
-					shot=((int)(target-totalruns)/((5-i)*6-j)-1)>10?rng(11):rng2(11,((int)(target-totalruns)/((5-i)*6-j)-1));
+					shot=((int)((ball<=6)?rng2(11,((int)(target-totalruns)/((5-i)*6-j))):rng2(11,((int)(target-totalruns)/((5-i)*6-j)-1))));
 				}
 		    else
 		    {


### PR DESCRIPTION
Essentially the Previous AI was a bit of a bottlejob in the final overs, where it would fall short at the last ball despite having a clear win condition.

```java
shot=((int)(target-totalruns)/((5-i)*6-j)-1)>10?rng(11):rng2(11,((int)(target-totalruns)/((5-i)*6-j)-1))
```
The above ternary at line 99 has been replaced by :
```java
  shot=((int)((ball<=6)?rng2(11,((int)(target-totalruns)/((5-i)*6-j))):rng2(11,((int)(target-totalruns)/((5-i)*6-j)-1))));
```